### PR TITLE
Bumped default Ghost API version to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "demo": "https://massively.ghost.io",
     "version": "1.0.1",
     "engines": {
-        "ghost": ">=2.0.0"
+        "ghost": ">=2.0.0",
+        "ghost-api": "v2"
     },
     "license": "MIT",
     "screenshots": {


### PR DESCRIPTION
This change is due to Content API becoming stable https://github.com/TryGhost/Ghost/releases/tag/2.10.0