### PR TITLE
Bug: gulp-sass 5 does not have a default Sass compiler

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@ const pump = require('pump');
 
 // gulp plugins and utils
 var livereload = require('gulp-livereload');
-var sass = require('gulp-sass');
+var sass = require('gulp-sass')(require('node-sass'));
 var zip = require('gulp-zip');
 var beeper = require('beeper');
 


### PR DESCRIPTION
PR fixes minor issue with gulp configuration when running `yarn zip`


#### Before

```
yarn zip
yarn run v1.22.17
warning massively@1.0.3: The engine "ghost" appears to be invalid.
warning massively@1.0.3: The engine "ghost-api" appears to be invalid.
$ gulp zip
[20:14:40] Using gulpfile ~/src/ghost/Massively/gulpfile.js
[20:14:40] Starting 'zip'...
[20:14:40] Starting 'css'...
Error in plugin "gulp-sass"
Message:
    
gulp-sass 5 does not have a default Sass compiler; please set one yourself.
Both the `sass` and `node-sass` packages are permitted.
For example, in your gulpfile:

  var sass = require('gulp-sass')(require('sass'));

[20:14:40] The following tasks did not complete: zip, <series>, css
[20:14:40] Did you forget to signal async completion?
```


#### After

```
yarn zip
yarn run v1.22.17
warning massively@1.0.3: The engine "ghost" appears to be invalid.
warning massively@1.0.3: The engine "ghost-api" appears to be invalid.
$ gulp zip
[20:23:16] Using gulpfile ~/src/ghost/Massively/gulpfile.js
[20:23:16] Starting 'zip'...
[20:23:16] Starting 'css'...
[20:23:16] Finished 'css' after 94 ms
[20:23:16] Starting 'zipper'...
[20:23:16] Finished 'zipper' after 92 ms
[20:23:16] Finished 'zip' after 188 ms
Done in 0.52s.
```