### PR TITLE
Fix author website not working on Author page

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -23,7 +23,7 @@ into the {body} of the default.hbs template --}}
                 {{plural ../pagination.total empty='No posts' singular='% post' plural='% posts'}} <span class="bull">&bull;</span>
             </div>
             {{#if website}}
-            <a href="{{url}}" class="icon fa-globe" title="Website"><span class="label">Website</span></a>
+            <a href="{{website}}" class="icon fa-globe" title="Website"><span class="label">Website</span></a>
             {{/if}}
             {{#if twitter}}
             <a href="{{twitter_url}}" class="icon fa-twitter" title="Twitter"><span class="label">Twitter</span></a>


### PR DESCRIPTION
Previously was using the {{url}} helper which pointed to the current page in Ghost and not the author's website.