### PR TITLE
Add search powered by ghost's new search feature

### DIFF
--- a/partials/navigation.hbs
+++ b/partials/navigation.hbs
@@ -12,5 +12,6 @@
         <li><a href="{{facebook_url @site.facebook}}" class="icon fa-facebook" title="Facebook"><span class="label">Facebook</span></a></li>
         {{/if}}
         <li><a href="https://feedly.com/i/subscription/feed/{{@site.url}}/rss/" class="icon fa-rss" target="_blank" rel="noopener"><span class="label" title="RSS">RSS</span></a></li>
+	<li><a href="#/search" class="icon fa-search" title="Search"><span class="label">Search</span></a></li>
     </ul>
 </nav>


### PR DESCRIPTION
Added simple search powered by [Ghost's new native search feature](https://ghost.org/docs/themes/search/). I used the URL-based approach for simplicity's sake, but alternatively this could be done using the `data-ghost-search` data attribute. Feedback/changes welcome!