### PR TITLE
Exclude agent docs from theme zip

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,7 +50,9 @@ function zipper(done) {
             '!node_modules', '!node_modules/**',
             '!dist', '!dist/**',
             '!pnpm-lock.yaml',
-            '!pnpm-workspace.yaml'
+            '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
         ], {encoding: false}),
         zip(filename),
         dest(targetDir)


### PR DESCRIPTION
## Summary
- Excludes `AGENTS.md` and `CLAUDE.md` from the theme zip source globs.
- Keeps generated theme archives limited to runtime theme content.

## Validation
- `pnpm zip`, with the generated archive inspected for `AGENTS.md` / `CLAUDE.md`.
