### PR TITLE
Renamed CI gate check to the org-standard "Required checks pass"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
 
       - run: pnpm test
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Branch protection on this repo currently requires the status check named exactly `All tests pass`. Requiring an individual/legacy check name couples the branch ruleset to this repo's particular CI naming: rename the job and the required check silently no longer exists, blocking every PR.

The org is standardizing every repository on one stable aggregator check named `Required checks pass` (the `repo-ci-required-check` convention), so rulesets can be managed uniformly across repos.

## What

- Renamed the existing aggregator job in `.github/workflows/test.yml` from `all-tests-pass` / `All tests pass` to `required-checks-pass` / `Required checks pass`.
- Coverage is unchanged: the gate still `needs: [test]`, the only other job in the workflow.
- Top-level `permissions: contents: read` was already present; no other CI changes.

## Note

The branch ruleset is being updated in the same pass to require `Required checks pass`, so this PR must go green on the new gate before merge.